### PR TITLE
Bug/frontend crashes after reload

### DIFF
--- a/backend/useCases/getFileTree.go
+++ b/backend/useCases/getFileTree.go
@@ -73,7 +73,7 @@ func buildSubFileTree(parentTree *models.FileTreeDto, pathPartsWithoutFileExtens
 		}
 
 		child := models.FileTreeDto{
-			Id:       currentNode.Id,
+			Id:       uuid.New().String(),
 			Name:     currentPathPart,
 			Children: []models.FileTreeDto{},
 			Files:    []models.FileDto{},
@@ -81,27 +81,6 @@ func buildSubFileTree(parentTree *models.FileTreeDto, pathPartsWithoutFileExtens
 		currentNode.Children = append(currentNode.Children, child)
 		currentNode = &child
 	}
-
-	//for isGettingMatchingItemInHierarchy {
-	//	indexOfMatchingChild := findChildIndexInChildrenOfFileTree(currentNode, remainingPathParts[0])
-	//
-	//	hasMatchingChild := indexOfMatchingChild >= 0
-	//	if hasMatchingChild {
-	//		currentNode = &currentNode.Children[indexOfMatchingChild]
-	//	} else {
-	//		child := models.FileTreeDto{
-	//			Id:       currentNode.Id,
-	//			Name:     currentPathPart,
-	//			Children: []models.FileTreeDto{},
-	//			Files:    []models.FileDto{},
-	//		}
-	//		currentNode.Children = append(currentNode.Children, child)
-	//		currentNode = &child
-	//	}
-	//
-	//	remainingPathParts = remainingPathParts[1:]
-	//	isGettingMatchingItemInHierarchy = len(remainingPathParts) > 0
-	//}
 }
 
 func getThumbnailOfTree(rootFileTree *models.FileTreeDto, file models.FileTreeItem, pathPartsWithFileExtension []string) {
@@ -140,16 +119,12 @@ func getNodeAssociatedWithFileInTree(rootFileTree *models.FileTreeDto, pathParts
 	remainingPathParts := pathPartsWithFileExtension
 	currentNode := rootFileTree
 
-	for len(remainingPathParts) > 0 {
-		currentPathPart = remainingPathParts[0]
+	for i := 0; i < len(pathPartsWithFileExtension); i += 1 {
+		currentPathPart = remainingPathParts[i]
 		indexOfMatchingChild := findChildIndexInChildrenOfFileTree(currentNode, currentPathPart)
-		hasMatchingChild := indexOfMatchingChild >= 0 // cannot have match on the last element because the file name with extension is not included in the file tree
-
-		if hasMatchingChild {
+		if indexOfMatchingChild >= 0 {
 			currentNode = &currentNode.Children[indexOfMatchingChild]
 		}
-
-		remainingPathParts = remainingPathParts[1:]
 	}
 
 	return currentNode

--- a/backend/useCases/getFileTree.go
+++ b/backend/useCases/getFileTree.go
@@ -69,7 +69,7 @@ func buildSubFileTree(parentTree *models.FileTreeDto, pathPartsWithoutFileExtens
 			currentNode = &currentNode.Children[indexOfMatchingChild]
 		} else {
 			child := models.FileTreeDto{
-				Id:       uuid.New().String(),
+				Id:       currentNode.Id,
 				Name:     currentPathPart,
 				Children: []models.FileTreeDto{},
 				Files:    []models.FileDto{},

--- a/backend/useCases/getFileTree.go
+++ b/backend/useCases/getFileTree.go
@@ -19,8 +19,13 @@ var GetFileTreeUseCaseRoute = router.Route{
 	Method:  http.MethodGet,
 }
 
+var fileTree models.FileTreeDto
+
 func getFileTreeUseCase(w http.ResponseWriter, r *http.Request) {
-	fileTree := GetFileTreeDto(lib.FileTreeItems)
+	if fileTree.Id == "" {
+		fileTree = GetFileTreeDto(lib.FileTreeItems)
+	}
+
 	encodedBytes, err := json.Marshal(fileTree.Children)
 	if err != nil {
 		router.ErrorHandler(w, fmt.Sprintf("Could not marshal file tree: %v", err.Error()), http.StatusInternalServerError)
@@ -43,7 +48,7 @@ func GetFileTreeDto(filesArray []models.FileTreeItem) models.FileTreeDto {
 
 	for _, file := range filesArray {
 		pathParts := usecases.GetPartsOfPath(file)
-		addThumbnailToTree(&rootFileHierarchy, file, pathParts)
+		getThumbnailOfTree(&rootFileHierarchy, file, pathParts)
 	}
 
 	for _, file := range filesArray {
@@ -55,37 +60,51 @@ func GetFileTreeDto(filesArray []models.FileTreeItem) models.FileTreeDto {
 }
 
 func buildSubFileTree(parentTree *models.FileTreeDto, pathPartsWithoutFileExtension []string) {
-	var currentPathPart string
 	remainingPathParts := pathPartsWithoutFileExtension
 	currentNode := parentTree
 
-	isGettingMatchingItemInHierarchy := len(remainingPathParts[0]) > 0
-	for isGettingMatchingItemInHierarchy {
-		currentPathPart = remainingPathParts[0]
+	for i := 0; i < len(remainingPathParts); i += 1 {
+		currentPathPart := remainingPathParts[i]
 		indexOfMatchingChild := findChildIndexInChildrenOfFileTree(currentNode, currentPathPart)
 
-		hasMatchingChild := indexOfMatchingChild >= 0
-		if hasMatchingChild {
+		if indexOfMatchingChild >= 0 {
 			currentNode = &currentNode.Children[indexOfMatchingChild]
-		} else {
-			child := models.FileTreeDto{
-				Id:       currentNode.Id,
-				Name:     currentPathPart,
-				Children: []models.FileTreeDto{},
-				Files:    []models.FileDto{},
-			}
-			currentNode.Children = append(currentNode.Children, child)
-			currentNode = &child
+			continue
 		}
 
-		remainingPathParts = remainingPathParts[1:]
-		if len(remainingPathParts) == 0 {
-			isGettingMatchingItemInHierarchy = false
+		child := models.FileTreeDto{
+			Id:       currentNode.Id,
+			Name:     currentPathPart,
+			Children: []models.FileTreeDto{},
+			Files:    []models.FileDto{},
 		}
+		currentNode.Children = append(currentNode.Children, child)
+		currentNode = &child
 	}
+
+	//for isGettingMatchingItemInHierarchy {
+	//	indexOfMatchingChild := findChildIndexInChildrenOfFileTree(currentNode, remainingPathParts[0])
+	//
+	//	hasMatchingChild := indexOfMatchingChild >= 0
+	//	if hasMatchingChild {
+	//		currentNode = &currentNode.Children[indexOfMatchingChild]
+	//	} else {
+	//		child := models.FileTreeDto{
+	//			Id:       currentNode.Id,
+	//			Name:     currentPathPart,
+	//			Children: []models.FileTreeDto{},
+	//			Files:    []models.FileDto{},
+	//		}
+	//		currentNode.Children = append(currentNode.Children, child)
+	//		currentNode = &child
+	//	}
+	//
+	//	remainingPathParts = remainingPathParts[1:]
+	//	isGettingMatchingItemInHierarchy = len(remainingPathParts) > 0
+	//}
 }
 
-func addThumbnailToTree(rootFileTree *models.FileTreeDto, file models.FileTreeItem, pathPartsWithFileExtension []string) {
+func getThumbnailOfTree(rootFileTree *models.FileTreeDto, file models.FileTreeItem, pathPartsWithFileExtension []string) {
 	if file.Type != enums.IMAGE {
 		return
 	}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -20,11 +20,9 @@ export const Route = createRootRoute({
 
 function Root() {
   return (
-    // <div className="grid gap-4">
     <main className="p-4 overflow-y-auto h-full max-h-[100lvh]">
       <Outlet />
     </main>
-    // </div>
   );
 }
 

--- a/frontend/src/routes/folders/_folderLayout/$folderId/index.tsx
+++ b/frontend/src/routes/folders/_folderLayout/$folderId/index.tsx
@@ -15,10 +15,6 @@ export const Route = createFileRoute('/folders/_folderLayout/$folderId/')({
 function AudioFilePage() {
   const { fileTrees } = RootLayoutRoute.useLoaderData();
   const { folderId } = useParams({ strict: false });
-  const baka = Route.useLoaderData();
-  console.log('RR', baka);
-
-  console.log('TT', folderId, fileTrees);
   const selectedFolder = getFolderFromFileTree(fileTrees, folderId);
   if (!selectedFolder) {
     const message = `Could not find folder with id '${folderId}'`;

--- a/frontend/src/routes/folders/_folderLayout/$folderId/index.tsx
+++ b/frontend/src/routes/folders/_folderLayout/$folderId/index.tsx
@@ -15,6 +15,10 @@ export const Route = createFileRoute('/folders/_folderLayout/$folderId/')({
 function AudioFilePage() {
   const { fileTrees } = RootLayoutRoute.useLoaderData();
   const { folderId } = useParams({ strict: false });
+  const baka = Route.useLoaderData();
+  console.log('RR', baka);
+
+  console.log('TT', folderId, fileTrees);
   const selectedFolder = getFolderFromFileTree(fileTrees, folderId);
   if (!selectedFolder) {
     const message = `Could not find folder with id '${folderId}'`;


### PR DESCRIPTION
- Change getFileTree to handle the actual calculated fileTree as a singleton saved in memory to prevent changes in the ids
- Refactor getFileTree to use for instead of while loops in some functions to improve the readability

Closes #48 and Closes #51 