### PR TITLE
Fix calculation of the byte range end to prevent the video element from crashing

### DIFF
--- a/backend/useCases/utilities/getRequestedRangesFromHeaderField.go
+++ b/backend/useCases/utilities/getRequestedRangesFromHeaderField.go
@@ -33,9 +33,9 @@ func GetRequestedRangesFromHeaderField(input GetRequestRangesInput) (start int64
 	return start, end
 }
 
-func getStringifiedRange(rangeHeaderWithPrefix string) (stringifiedStart string, stringifiedEnd string) {
-	stringifiedStart = ""
-	stringifiedEnd = ""
+func getStringifiedRange(rangeHeaderWithPrefix string) (string, string) {
+	stringifiedStart := ""
+	stringifiedEnd := ""
 	rangeHeaderWithoutPrefix := strings.TrimPrefix(rangeHeaderWithPrefix, "bytes=")
 	rangeParts := strings.Split(rangeHeaderWithoutPrefix, "-")
 
@@ -72,17 +72,17 @@ type getEndInput struct {
 }
 
 func getEnd(input getEndInput) (int64, error) {
-	if input.stringifiedEnd == "" {
-		return input.start + input.chunkSize, nil
-	}
+	end := input.start + input.chunkSize
 
-	end, err := strconv.ParseInt(input.stringifiedEnd, 10, 64)
-	if err != nil {
-		return 0, err
-	}
+	if input.stringifiedEnd != "" {
+		parsedEnd, err := strconv.ParseInt(input.stringifiedEnd, 10, 64)
+		if err != nil {
+			return 0, err
+		}
 
-	if end == 0 {
-		end = input.start + input.chunkSize
+		if parsedEnd != 0 {
+			end = parsedEnd
+		}
 	}
 
 	if end > input.fileSize {

--- a/backend/useCases/utilities/getRequestedRangesFromHeaderField_test.go
+++ b/backend/useCases/utilities/getRequestedRangesFromHeaderField_test.go
@@ -83,8 +83,10 @@ func Test_getEnd(t *testing.T) {
 func Test_GetRequestedRangesFromHeaderField(t *testing.T) {
 	inputs := []models.TestData[GetRequestRangesInput, [2]int64]{
 		{Title: "Should return zero to chunk size on empty range header", Input: GetRequestRangesInput{"", 1024, 0}, Expected: [2]int64{0, 1024}},
-		{Title: "Should return zero to chuck size on incomplete range header", Input: GetRequestRangesInput{"bytes=", 1024, 0}, Expected: [2]int64{0, 1024}},
-		{Title: "Should return start and sum of chunk size with start on range header with only start", Input: GetRequestRangesInput{"bytes=1-", 1024, 0}, Expected: [2]int64{1, 1025}},
+		{Title: "Should return zero to chuck size on incomplete range header", Input: GetRequestRangesInput{"bytes=", 1024, 1080}, Expected: [2]int64{0, 1024}},
+		{Title: "Should return zero to chuck size on incomplete range header and zero file size", Input: GetRequestRangesInput{"bytes=", 1024, 0}, Expected: [2]int64{0, 0}},
+		{Title: "Should return start and sum of chunk size with only start on range header", Input: GetRequestRangesInput{"bytes=1-", 1024, 1080}, Expected: [2]int64{1, 1025}},
+		{Title: "Should return start and zero with only start on range header and zero file size", Input: GetRequestRangesInput{"bytes=1-", 1024, 0}, Expected: [2]int64{1, 0}},
 		{Title: "Should return start and file size on header greater than chunk size", Input: GetRequestRangesInput{"bytes=1-2000", 1024, 512}, Expected: [2]int64{1, 512}},
 		{Title: "Should return start and end from range header", Input: GetRequestRangesInput{"bytes=1-2000", 1024, 16000}, Expected: [2]int64{1, 2000}},
 	}


### PR DESCRIPTION
Fix getEnd by respecting the file size in each case and prevent an value for end that is greater than the fileSize; Fix broken tests for getREquestRangesFromHeaderField

Closes #8 
But now a Chrome related issue occurres (#78 )