### PR TITLE
If a dot is present in the file name, then the calculation of the name is wrong

### DIFF
--- a/backend/lib/utilities/logic/getFilenameWIthoutExtension.go
+++ b/backend/lib/utilities/logic/getFilenameWIthoutExtension.go
@@ -8,10 +8,13 @@ import (
 func GetFilenameWithoutExtension(filename string) string {
 	fileExtension := path.Ext(filename)
 	fileNameWithoutExtension := strings.Replace(filename, fileExtension, "", 1)
-	// used if two file names are chained e. g. .mp3.vtt
-	fileExtension = path.Ext(fileNameWithoutExtension)
-	if fileExtension != "" {
-		fileNameWithoutExtension = strings.Replace(fileNameWithoutExtension, fileExtension, "", 1)
+
+	isSubtitleFile := fileExtension == ".vtt"
+	if isSubtitleFile {
+		fileExtension = path.Ext(fileNameWithoutExtension)
+		if fileExtension != "" {
+			fileNameWithoutExtension = strings.Replace(fileNameWithoutExtension, fileExtension, "", 1)
+		}
 	}
 
 	return fileNameWithoutExtension

--- a/backend/lib/utilities/logic/getFilenameWIthoutExtension_test.go
+++ b/backend/lib/utilities/logic/getFilenameWIthoutExtension_test.go
@@ -13,6 +13,10 @@ func Test_GetFilenameWithoutExtension(t *testing.T) {
 		{Title: "Should return file name of wav input", Input: "example.wav", Expected: "example"},
 		{Title: "Should return file name of wav subtitle input", Input: "example.wav.vtt", Expected: "example"},
 		{Title: "Should return file name of mp4 file", Input: "example.mp4", Expected: "example"},
+		{Title: "Should return file name that contains one dot for a media file", Input: "1. example.mp4", Expected: "1. example"},
+		{Title: "Should return file name that contains one dot for a subtitle file", Input: "1. example.wav.vtt", Expected: "1. example"},
+		{Title: "Should return file name that contains one dot for a media file", Input: "1. 2. 3. example.mp4", Expected: "1. 2. 3. example"},
+		{Title: "Should return file name that contains multiple dots for a subtitle file", Input: "1. 2. 3. example.wav.vtt", Expected: "1. 2. 3. example"},
 	}
 
 	for _, input := range inputs {


### PR DESCRIPTION
Change GetFilenameWithoutExtension by adding a check for subtitle files; Add missing tests for multiple dots inside the file name

Closes #80 